### PR TITLE
feat: allow loadHeaderRow to pass forwards a values.get options parameter

### DIFF
--- a/lib/GoogleSpreadsheetWorksheet.js
+++ b/lib/GoogleSpreadsheetWorksheet.js
@@ -287,9 +287,9 @@ class GoogleSpreadsheetWorksheet {
 
   // ROW BASED FUNCTIONS ///////////////////////////////////////////////////////////////////////////
 
-  async loadHeaderRow(headerRowIndex) {
+  async loadHeaderRow(headerRowIndex, options) {
     if (headerRowIndex !== undefined) this._headerRowIndex = headerRowIndex;
-    const rows = await this.getCellsInRange(`A${this._headerRowIndex}:${this.lastColumnLetter}${this._headerRowIndex}`);
+    const rows = await this.getCellsInRange(`A${this._headerRowIndex}:${this.lastColumnLetter}${this._headerRowIndex}`, options);
     if (!rows) {
       throw new Error('No values in the header row - fill the first row with header values before trying to interact with rows');
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Theo Ephraim <theozero@gmail.com> (https://theoephraim.com)",
   "name": "google-spreadsheet",
   "description": "Google Sheets API (v4) -- simple interface to read/write data and manage sheets",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "Unlicense",
   "keywords": [
     "google spreadsheets",


### PR DESCRIPTION
It is important for Noloco to know whether a column has been created from an `IMPORTRANGE` formula or not. The reason for this is that when we save a row on update, we should blank out any values in these columns to prevent this error from occuring:

![Screenshot 2023-02-03 at 11 25 33](https://user-images.githubusercontent.com/6977616/216591906-301bce23-d39b-4ee3-b2dc-e43dcf6301da.png)

Right now we have no way to know this, however when we load header rows we can use `valueRenderOption: 'FORMULA'` to load any forumlae that are in the header row and spot `IMPORTRANGE`, we can then handle this as needed in update mutations but we need the parameter to be accepted in the method first which is what this change does.