### PR TITLE
fix: stringify header before trimming when loading header row

### DIFF
--- a/lib/GoogleSpreadsheetWorksheet.js
+++ b/lib/GoogleSpreadsheetWorksheet.js
@@ -293,7 +293,7 @@ class GoogleSpreadsheetWorksheet {
     if (!rows) {
       throw new Error('No values in the header row - fill the first row with header values before trying to interact with rows');
     }
-    this.headerValues = _.map(rows[0], (header) => header.trim());
+    this.headerValues = _.map(rows[0], (header) => String(header).trim());
     if (!_.compact(this.headerValues).length) {
       throw new Error('All your header cells are blank - fill the first row with header values before trying to interact with rows');
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Theo Ephraim <theozero@gmail.com> (https://theoephraim.com)",
   "name": "@noloco/google-spreadsheet",
   "description": "Google Sheets API (v4) -- simple interface to read/write data and manage sheets",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "Unlicense",
   "keywords": [
     "google spreadsheets",


### PR DESCRIPTION
Now that we try to load headers from a worksheet both in their display format and as formulas it turns out that there is an issue with non-string headers such as this:

<img width="107" alt="Screenshot 2023-02-08 at 13 26 06" src="https://user-images.githubusercontent.com/6977616/217542809-28e8cfad-0608-46ee-bc53-dd47bceb208c.png">

When loading this with value render set to formula we will actually get an error `TypeError: header.trim is not a function` on the numeric header. It appears that the same might happen for date headers based on feedback from the customer.

Because we technically supported these before I think we should continue to support them, however we should make sure that `header` is a string before calling `.trim()` on it.