### PR TITLE
fix: metadata method types, safely add params for getRows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noloco/google-spreadsheet",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Google Sheets API -- simple interface to read/write data and manage sheets",
   "keywords": [
     "google spreadsheets",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { GoogleSpreadsheetWorksheet } from './lib/GoogleSpreadsheetWorksheet';
 export { GoogleSpreadsheetRow } from './lib/GoogleSpreadsheetRow';
 export { GoogleSpreadsheetCell } from './lib/GoogleSpreadsheetCell';
 export { GoogleSpreadsheetCellErrorValue } from './lib/GoogleSpreadsheetCellErrorValue';
+export type { GetValuesRequestOptions } from './lib/types/sheets-types';

--- a/src/lib/GoogleSpreadsheet.ts
+++ b/src/lib/GoogleSpreadsheet.ts
@@ -1,5 +1,4 @@
 import Axios, {AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig,} from 'axios';
-
 import {Stream} from 'stream';
 import * as _ from './lodash';
 import {GoogleSpreadsheetWorksheet} from './GoogleSpreadsheetWorksheet';
@@ -681,8 +680,8 @@ export class GoogleSpreadsheet {
     metadataKey:DeveloperMetadataKey,
     metadataValue:DeveloperMetadataValue,
     location:Partial<DeveloperMetadataLocation>,
-    visibility:DeveloperMetadataVisibility,
-    metadataId:DeveloperMetadataId
+    visibility?:DeveloperMetadataVisibility,
+    metadataId?:DeveloperMetadataId
   ) {
     // Request type = `createDeveloperMetadata`
     // https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.developerMetadata#DeveloperMetadata
@@ -719,8 +718,8 @@ export class GoogleSpreadsheet {
     metadataKey:DeveloperMetadataKey,
     metadataValue:DeveloperMetadataValue,
     sheetId: number,
-    visibility:DeveloperMetadataVisibility,
-    metadataId:DeveloperMetadataId
+    visibility?:DeveloperMetadataVisibility,
+    metadataId?:DeveloperMetadataId
   ) {
     return this._createDeveloperMetadata(
       metadataKey,
@@ -737,8 +736,8 @@ export class GoogleSpreadsheet {
     metadataKey:DeveloperMetadataKey,
     metadataValue:DeveloperMetadataValue,
     range: DimensionRange,
-    visibility:DeveloperMetadataVisibility,
-    metadataId:DeveloperMetadataId
+    visibility?: DeveloperMetadataVisibility,
+    metadataId?: DeveloperMetadataId
   ) {
     return this._createDeveloperMetadata(
       metadataKey,

--- a/src/lib/GoogleSpreadsheetCell.ts
+++ b/src/lib/GoogleSpreadsheetCell.ts
@@ -249,10 +249,10 @@ export class GoogleSpreadsheetCell {
   }
 
   async createDeveloperMetadata(
-    metadataKey:DeveloperMetadataKey,
-    metadataValue:DeveloperMetadataValue,
-    visibility:DeveloperMetadataVisibility,
-    metadataId:DeveloperMetadataId
+    metadataKey: DeveloperMetadataKey,
+    metadataValue: DeveloperMetadataValue,
+    visibility?: DeveloperMetadataVisibility,
+    metadataId?: DeveloperMetadataId
   ) {
     return this._sheet._spreadsheet.createRangeDeveloperMetadata(
       metadataKey,


### PR DESCRIPTION
Fixes related to getting our app working on the updated version

- Exports a type to avoid us manually typing it in our codebase
- Fixes non-optional args for metadata
- Fixes including the extra options on row requests
	- Requests error with undefined values on params
 
@darraghmckay I think our best way to release this is to run the release script vs this branch, let it bump the version & then merge afterwards 🤔 