### PR TITLE
fix: handle fully numeric headers in sheet

### DIFF
--- a/src/lib/GoogleSpreadsheetWorksheet.ts
+++ b/src/lib/GoogleSpreadsheetWorksheet.ts
@@ -361,7 +361,7 @@ export class GoogleSpreadsheetWorksheet {
     if (!rows) {
       throw new Error('No values in the header row - fill the first row with header values before trying to interact with rows');
     }
-    this._headerValues = _.map(rows[0], (header) => header?.trim());
+    this._headerValues = _.map(rows[0], (header) => header?.toString().trim());
     if (!_.compact(this.headerValues).length) {
       throw new Error('All your header cells are blank - fill the first row with header values before trying to interact with rows');
     }


### PR DESCRIPTION
Handles issues with fully numeric headers not having a `trim` method by first passing them through `toString`
This also lets us keep the nullish operator so we can avoid `undefined` or `null` as headers.