### PR TITLE
chore: add rendering options for header row

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - DeveloperMetadata is supported
 - Retries are supported when rate limited
 - Safer handling of numeric headers
-- Support for providing valueRenderOption when loading rows
+- Support for providing valueRenderOption when loading rows & headers
 - Support for reading cell & row metadata
 
 [![NPM version](https://img.shields.io/npm/v/google-spreadsheet)](https://www.npmjs.com/package/google-spreadsheet)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noloco/google-spreadsheet",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "Google Sheets API -- simple interface to read/write data and manage sheets",
   "keywords": [
     "google spreadsheets",

--- a/src/lib/GoogleSpreadsheetWorksheet.ts
+++ b/src/lib/GoogleSpreadsheetWorksheet.ts
@@ -363,9 +363,9 @@ export class GoogleSpreadsheetWorksheet {
     }
   }
 
-  async loadHeaderRow(headerRowIndex?: number) {
+  async loadHeaderRow(headerRowIndex?: number, options?: GetValuesRequestOptions) {
     if (headerRowIndex !== undefined) this._headerRowIndex = headerRowIndex;
-    const rows = await this.getCellsInRange(this._headerRange);
+    const rows = await this.getCellsInRange(this._headerRange, options);
     this._processHeaderRow(rows);
   }
 


### PR DESCRIPTION
Includes options for rendering values when loading the header row.

This was missed in #19 