### PR TITLE
chore: throw explicit error if missing spreadsheetUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noloco/google-spreadsheet",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Google Sheets API -- simple interface to read/write data and manage sheets",
   "keywords": [
     "google spreadsheets",

--- a/src/lib/GoogleSpreadsheet.ts
+++ b/src/lib/GoogleSpreadsheet.ts
@@ -1,31 +1,29 @@
-import Axios, {
-  AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig,
-} from 'axios';
+import Axios, {AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig,} from 'axios';
 
-import { Stream } from 'stream';
+import {Stream} from 'stream';
 import * as _ from './lodash';
-import { GoogleSpreadsheetWorksheet } from './GoogleSpreadsheetWorksheet';
-import { axiosParamsSerializer, getFieldMask } from './utils';
+import {GoogleSpreadsheetWorksheet} from './GoogleSpreadsheetWorksheet';
+import {axiosParamsSerializer, getFieldMask} from './utils';
 import {
-  A1Range,
-  DataFilter,
-  DeveloperMetadataDataFilter,
-  DeveloperMetadataId,
-  DeveloperMetadataKey,
-  DeveloperMetadataLocation,
-  DeveloperMetadataValue,
-  DeveloperMetadataVisibility,
-  DimensionRange,
-  GridRange,
-  NamedRangeId,
-  SpreadsheetId,
-  SpreadsheetProperties,
-  WorksheetId,
-  WorksheetProperties,
+    A1Range,
+    DataFilter,
+    DeveloperMetadataDataFilter,
+    DeveloperMetadataId,
+    DeveloperMetadataKey,
+    DeveloperMetadataLocation,
+    DeveloperMetadataValue,
+    DeveloperMetadataVisibility,
+    DimensionRange,
+    GridRange,
+    NamedRangeId,
+    SpreadsheetId,
+    SpreadsheetProperties,
+    WorksheetId,
+    WorksheetProperties,
 } from './types/sheets-types';
-import { PermissionRoles, PermissionsList, PublicPermissionRoles } from './types/drive-types';
-import { RecursivePartial } from './types/util-types';
-import { AUTH_MODES, GoogleApiAuth } from './types/auth-types';
+import {PermissionRoles, PermissionsList, PublicPermissionRoles} from './types/drive-types';
+import {RecursivePartial} from './types/util-types';
+import {AUTH_MODES, GoogleApiAuth} from './types/auth-types';
 
 
 const SHEETS_API_BASE_URL = 'https://sheets.googleapis.com/v4/spreadsheets';
@@ -304,7 +302,7 @@ export class GoogleSpreadsheet {
       },
     });
     if (!response.data?.spreadsheetUrl) {
-      throw new Error(`Failed to load document info. Status: ${response.status},  Status Text: ${response.statusText}, Data: ${response.data}`);
+      throw new Error(`Failed to load document info. Status: ${response.status},  Status Text: ${response.statusText}, Data: ${JSON.stringify(response.data)}`);
     }
 
     this._spreadsheetUrl = response.data.spreadsheetUrl;

--- a/src/lib/GoogleSpreadsheet.ts
+++ b/src/lib/GoogleSpreadsheet.ts
@@ -303,6 +303,10 @@ export class GoogleSpreadsheet {
         ...includeCells && { includeGridData: true },
       },
     });
+    if (!response.data?.spreadsheetUrl) {
+      throw new Error(`Failed to load document info. Status: ${response.status},  Status Text: ${response.statusText}, Data: ${response.data}`);
+    }
+
     this._spreadsheetUrl = response.data.spreadsheetUrl;
     this._rawProperties = response.data.properties;
     _.each(response.data.sheets, (s) => this._updateOrCreateSheet(s));


### PR DESCRIPTION
This pull request includes an important error handling improvement in the `GoogleSpreadsheet` class. Specifically, it adds a check to ensure that the `spreadsheetUrl` is present in the response data and throws an error if it is not.

Error handling improvement:

* [`src/lib/GoogleSpreadsheet.ts`](diffhunk://#diff-f7e44d5fb544173fdad149af688d2e606449aa57967678c8e664da1b80792046R306-R309): Added a check to verify the presence of `spreadsheetUrl` in the response data and throw an error with detailed status information if it is missing.